### PR TITLE
@vtrifonov Make it catch any filename ending with .har

### DIFF
--- a/HARRepo.FileManager.API/Validators/FileUploadValidator.cs
+++ b/HARRepo.FileManager.API/Validators/FileUploadValidator.cs
@@ -20,7 +20,7 @@ namespace HARRepo.FileManager.API.Validators
                 .Cascade(CascadeMode.Stop)
                 .NotNull()
                 .NotEmpty()
-                .Matches(@"^(?:[\w]\:|\\)(\\[a-z_\-\s0-9\.]+)+\.har$")
+                .Matches(@"^(.+\.har$")
                 .WithMessage("File is not with the correct extension.");
 
             RuleFor(x => x.Content)

--- a/HARRepo.FileManager.API/Validators/FileUploadValidator.cs
+++ b/HARRepo.FileManager.API/Validators/FileUploadValidator.cs
@@ -20,7 +20,7 @@ namespace HARRepo.FileManager.API.Validators
                 .Cascade(CascadeMode.Stop)
                 .NotNull()
                 .NotEmpty()
-                .Matches(@"^(.+\.har$")
+                .Matches(@"^.+\.har$")
                 .WithMessage("File is not with the correct extension.");
 
             RuleFor(x => x.Content)


### PR DESCRIPTION
Seems that there's a problem with the provided regex `^(?:[\w]\:|\\)(\\[a-z_\-\s0-9\.]+)+\.har$` as it does not match `test.har` so can we make it a little bit simpler